### PR TITLE
Add basic navigation menu

### DIFF
--- a/Cadence DJ/LocalizedStrings.swift
+++ b/Cadence DJ/LocalizedStrings.swift
@@ -22,4 +22,21 @@ enum LocalizedStrings {
         "Done",
         comment: "Button title to complete a flow."
     )
+
+    enum Menu {
+        static let generatePlaylist = NSLocalizedString(
+            "Generate playlist",
+            comment: "Menu item title to generate a playlist based on the selected cadence."
+        )
+
+        static let trackCadence = NSLocalizedString(
+            "Track cadence",
+            comment: "Menu item title to track the user's cadence while running or cycling."
+        )
+
+        static let placeholder = NSLocalizedString(
+            "Select a menu option",
+            comment: "Text displayed if detail view is visible with no menu option selected."
+        )
+    }
 }

--- a/Cadence DJ/Models/GlobalDefaults.swift
+++ b/Cadence DJ/Models/GlobalDefaults.swift
@@ -1,0 +1,11 @@
+//
+//  GlobalDefaults.swift
+//  Cadence DJ
+//
+//  Created by Daniel Luo on 8/15/25.
+//
+
+enum GlobalDefaults {
+    static let defaultCadence = 170
+    static let cadenceRange = 100...250
+}

--- a/Cadence DJ/Models/MenuOption.swift
+++ b/Cadence DJ/Models/MenuOption.swift
@@ -1,0 +1,24 @@
+//
+//  MenuOption.swift
+//  Cadence DJ
+//
+//  Created by Daniel Luo on 8/15/25.
+//
+
+import Foundation
+
+enum MenuOption: Int, Hashable, Identifiable, CaseIterable, Codable {
+    case generatePlaylist
+    case trackCadence
+
+    var id: Int { rawValue }
+
+    var localizedName: String {
+        switch self {
+        case .generatePlaylist:
+            LocalizedStrings.Menu.generatePlaylist
+        case .trackCadence:
+            LocalizedStrings.Menu.trackCadence
+        }
+    }
+}

--- a/Cadence DJ/Views/CadenceSelectorView.swift
+++ b/Cadence DJ/Views/CadenceSelectorView.swift
@@ -8,12 +8,7 @@
 import SwiftUI
 
 struct CadenceSelectorView: View {
-    private enum Constants {
-        static let defaultValue = 170
-        static let range = 100...250
-    }
-
-    @State private var cadenceValue = Constants.defaultValue // TODO: pass in from above
+    @Binding var cadenceValue: Int
     @FocusState private var isFocused
 
     var body: some View {
@@ -27,7 +22,7 @@ struct CadenceSelectorView: View {
             Stepper(
                 "",
                 value: $cadenceValue,
-                in: Constants.range
+                in: GlobalDefaults.cadenceRange
             )
             .labelsHidden()
             .accessibilityLabel(LocalizedStrings.cadenceStepper)
@@ -36,7 +31,7 @@ struct CadenceSelectorView: View {
 
     private var textField: some View {
         TextField(
-            "\(Constants.defaultValue)",
+            "\(GlobalDefaults.defaultCadence)",
             value: $cadenceValue,
             format: .number.grouping(.never)
         )
@@ -60,10 +55,10 @@ struct CadenceSelectorView: View {
     }
 
     private func clampCadenceValue() {
-        cadenceValue = cadenceValue.clamped(to: Constants.range)
+        cadenceValue = cadenceValue.clamped(to: GlobalDefaults.cadenceRange)
     }
 }
 
 #Preview {
-    CadenceSelectorView()
+    CadenceSelectorView(cadenceValue: .constant(198))
 }

--- a/Cadence DJ/Views/MainView.swift
+++ b/Cadence DJ/Views/MainView.swift
@@ -37,7 +37,6 @@ struct MainView: View {
                 Text(LocalizedStrings.Menu.placeholder)
             }
         }
-
     }
 }
 

--- a/Cadence DJ/Views/MainView.swift
+++ b/Cadence DJ/Views/MainView.swift
@@ -8,8 +8,36 @@
 import SwiftUI
 
 struct MainView: View {
+    @State private var selectedCadence: Int = GlobalDefaults.defaultCadence
+    @State private var selectedMenuOption: MenuOption? // TODO: move to NavigationModel
+    private let menuOptions = MenuOption.allCases
+
     var body: some View {
-        CadenceSelectorView()
+        NavigationSplitView {
+            VStack {
+                CadenceSelectorView(cadenceValue: $selectedCadence)
+                .padding()
+
+                List(
+                    menuOptions,
+                    selection: $selectedMenuOption
+                ) { menuOption in
+                    NavigationLink(menuOption.localizedName, value: menuOption)
+                }
+                .scrollContentBackground(.hidden)
+            }
+        } detail: {
+            if let selectedMenuOption {
+                // TODO: replace with real views
+                VStack {
+                    Text(selectedMenuOption.localizedName)
+                    Text("Current cadence: \(selectedCadence)")
+                }
+            } else {
+                Text(LocalizedStrings.Menu.placeholder)
+            }
+        }
+
     }
 }
 


### PR DESCRIPTION
- Adds a simple menu that navigates to what will be NavigationStacks supporting the core features of the application.
- Manages cadence selection state centrally and passes it to child views.

https://github.com/user-attachments/assets/3a048fcb-3406-461c-9145-f990c0f16c8e

